### PR TITLE
make scikit-learn explicit in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.15.3
-sklearn>=0.20.0
+scikit-learn>=0.20.0
 tensorflow==1.0.0
 keras==2.1.2


### PR DESCRIPTION
`pip install -r requirements.txt` and `conda install --file requirements.txt` both fail when `scikit-learn` is references as `sklearn`.